### PR TITLE
#165763482 create high order component  for authentication

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,6 @@
         "argsIgnorePattern": "^_"
       }
     ],
-    "react/prefer-stateless-function": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-static-element-interactions": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
@@ -62,7 +61,6 @@
     "no-named-as-default": "off",
     "arrow-body-style": ["error", "as-needed"],
     "import/no-dynamic-require": "off",
-    "prettier/prettier":0,
     "no-shadow": [
       "error",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,6 +61,7 @@
     "no-named-as-default": "off",
     "arrow-body-style": ["error", "as-needed"],
     "import/no-dynamic-require": "off",
+    "prettier/prettier": 0,
     "no-shadow": [
       "error",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,13 +21,20 @@
   },
   "plugins": ["react", "prettier"],
   "rules": {
-    "prettier/prettier": "error",
     "newlines-between": "always",
     "react/forbid-prop-types": [2,
       {
         "forbid": ["object", "array"], "checkContextTypes": false, "checkChildContextTypes": false
       }
     ],
+    "no-unused-vars": [
+      "error",
+      {
+        "varsIgnorePattern": "^_",
+        "argsIgnorePattern": "^_"
+      }
+    ],
+    "react/prefer-stateless-function": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-static-element-interactions": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
@@ -55,6 +62,7 @@
     "no-named-as-default": "off",
     "arrow-body-style": ["error", "as-needed"],
     "import/no-dynamic-require": "off",
+    "prettier/prettier":0,
     "no-shadow": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dotenv": "^7.0.0",
     "lodash": "^4.17.11",
     "jest": "^24.7.1",
+    "jest-localstorage-mock": "^2.4.0",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",

--- a/src/__tests__/__actions__/following.test.js
+++ b/src/__tests__/__actions__/following.test.js
@@ -24,7 +24,7 @@ describe("test the following actions", () => {
   });
 
   describe("test fetch following", () => {
-    const location = { pathname: "gdfjbjhgdsfj" };
+    const location = { pathname: "/a-fake/path" };
     const history = { push: jest.fn() };
     test("should dispatch the success action after successfully following the user", () => {
       store = mockStore({});

--- a/src/__tests__/__actions__/following.test.js
+++ b/src/__tests__/__actions__/following.test.js
@@ -24,6 +24,8 @@ describe("test the following actions", () => {
   });
 
   describe("test fetch following", () => {
+    const location = { pathname: "gdfjbjhgdsfj" };
+    const history = { push: jest.fn() };
     test("should dispatch the success action after successfully following the user", () => {
       store = mockStore({});
       const expectedActions = [
@@ -34,9 +36,11 @@ describe("test the following actions", () => {
         status: 201,
         response: { message: "Follow successful" }
       });
-      return store.dispatch(followUser("claude")).then(() => {
-        expect(store.getActions()).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(followUser("claude", { location, history }))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        });
     });
 
     test("should dispatch the success action after successfully unfollowing the user", () => {
@@ -49,9 +53,11 @@ describe("test the following actions", () => {
         status: 202,
         response: { message: "You have unfollowed this author" }
       });
-      return store.dispatch(followUser("claude")).then(() => {
-        expect(store.getActions()).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(followUser("claude", { location, history }))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        });
     });
 
     test("should dispatch the failed action if there was a problem while following the user", () => {
@@ -64,9 +70,11 @@ describe("test the following actions", () => {
         status: 500,
         response: { message: "Error while following the user" }
       });
-      return store.dispatch(followUser("claude")).then(() => {
-        expect(store.getActions()).toEqual(expectedActions);
-      });
+      return store
+        .dispatch(followUser("claude", { location, history }))
+        .then(() => {
+          expect(store.getActions()).toEqual(expectedActions);
+        });
     });
   });
 });

--- a/src/__tests__/__utils__/checkAuth.test.js
+++ b/src/__tests__/__utils__/checkAuth.test.js
@@ -9,7 +9,7 @@ import { checkAuthComponent } from "../../utils/checkAuthUtils";
 import { EditArticle } from "../../views/EditArticle";
 import { article } from "../__mocks__/testData";
 
-describe.only("should test the check authenticated component", () => {
+describe("should test the check authenticated component", () => {
   const initialState = { article };
   const mockStore = configureStore();
   let wrapper;
@@ -38,6 +38,7 @@ describe.only("should test the check authenticated component", () => {
       </Provider>
     ).find("AuthenticatedComponent");
   });
+
   afterEach(() => {
     localStorage.__STORE__.clear();
   });

--- a/src/__tests__/__utils__/checkAuth.test.js
+++ b/src/__tests__/__utils__/checkAuth.test.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-underscore-dangle */
+import { mount } from "enzyme";
+import "@babel/polyfill";
+import React from "react";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { checkAuthComponent } from "../../utils/checkAuthUtils";
+import { EditArticle } from "../../views/EditArticle";
+import { article } from "../__mocks__/testData";
+
+describe.only("should test the check authenticated component", () => {
+  const initialState = { article };
+  const mockStore = configureStore();
+  let wrapper;
+  let store;
+  let ConditionalComponent;
+  const nextUrl = "/articles/new";
+  beforeEach(() => {
+    const props = {
+      article,
+      match: {
+        params: {
+          slug: "hello-world"
+        }
+      },
+      response: "",
+      location: { pathname: nextUrl },
+      history: []
+    };
+    store = mockStore(initialState);
+    ConditionalComponent = checkAuthComponent(EditArticle);
+    wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ConditionalComponent {...props} />
+        </MemoryRouter>
+      </Provider>
+    ).find("AuthenticatedComponent");
+  });
+  afterEach(() => {
+    localStorage.__STORE__.clear();
+  });
+  test("should redirect to next url if not logged in", () => {
+    localStorage.__STORE__.setItem("token", "");
+    expect(wrapper.props().history).toContain(`/sign_in?next=${nextUrl}`);
+  });
+
+  test("should return next component if the user is authenticated", () => {
+    localStorage.__STORE__.setItem("token", "helloWorld");
+    expect(wrapper.isEmptyRender()).not.toBeTruthy();
+  });
+});

--- a/src/__tests__/__utils__/checkAuth.test.js
+++ b/src/__tests__/__utils__/checkAuth.test.js
@@ -42,6 +42,7 @@ describe("should test the check authenticated component", () => {
   afterEach(() => {
     localStorage.__STORE__.clear();
   });
+
   test("should redirect to next url if not logged in", () => {
     localStorage.__STORE__.setItem("token", "");
     expect(wrapper.props().history).toContain(`/sign_in?next=${nextUrl}`);

--- a/src/__tests__/__utils__/checkAuth.test.js
+++ b/src/__tests__/__utils__/checkAuth.test.js
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { checkAuthComponent } from "../../utils/checkAuthUtils";
-import { EditArticle } from "../../views/EditArticle";
+import { Article } from "../../views/CreateEditHolder";
 import { article } from "../__mocks__/testData";
 
 describe("should test the check authenticated component", () => {
@@ -29,7 +29,7 @@ describe("should test the check authenticated component", () => {
       history: []
     };
     store = mockStore(initialState);
-    ConditionalComponent = checkAuthComponent(EditArticle);
+    ConditionalComponent = checkAuthComponent(Article);
     wrapper = mount(
       <Provider store={store}>
         <MemoryRouter>

--- a/src/__tests__/__views__/Login.test.js
+++ b/src/__tests__/__views__/Login.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import React from "react";
 import toJson from "enzyme-to-json";
 import { shallow } from "enzyme";
@@ -23,7 +24,9 @@ const props = {
   token: null,
   handleSignIn,
   handleTextInput,
-  socialAuth
+  socialAuth,
+  location: {},
+  history: []
 };
 const wrapper = shallow(<Login {...props} />);
 
@@ -106,14 +109,29 @@ describe("Login component", () => {
       wrapper.setProps({
         loginSuccess: true
       });
-      expect(instance.handleNavigation).toBeCalledWith("");
+      expect(instance.props.history).toContain("/");
       expect(handleSignIn).toHaveBeenCalledWith({
         email: formData.email.value,
         password: formData.password.value
       });
     });
+    it("should redirect the user to the next url on log in", () => {
+      localStorage.__STORE__.setItem("token", "helloWorld");
+      mockedFormData.mockReturnValue({});
+      Validator.formData = mockedFormData.bind(Validator);
+      wrapper.setProps({
+        password: formData.password.value,
+        email: formData.email.value,
+        loginSuccess: true,
+        location: { search: "?next=/articles/new" }
+      });
+      findElement(FormButton, 0).simulate("click");
 
-    test("should not signIn user if email and password are not provided", () => {
+      expect(instance.props.history).toContain("/articles/new");
+      localStorage.__STORE__.clear();
+    });
+
+    it("should not signIn user if email and password are not provided", () => {
       const errors = { email: "Email is required" };
       mockedFormData.mockReturnValue({ ...errors });
       Validator.formData = mockedFormData.bind(Validator);

--- a/src/__tests__/__views__/Login.test.js
+++ b/src/__tests__/__views__/Login.test.js
@@ -115,7 +115,8 @@ describe("Login component", () => {
         password: formData.password.value
       });
     });
-    it("should redirect the user to the next url on log in", () => {
+
+    test("should redirect the user to the next url on log in", () => {
       localStorage.__STORE__.setItem("token", "helloWorld");
       mockedFormData.mockReturnValue({});
       Validator.formData = mockedFormData.bind(Validator);
@@ -131,7 +132,7 @@ describe("Login component", () => {
       localStorage.__STORE__.clear();
     });
 
-    it("should not signIn user if email and password are not provided", () => {
+    test("should not signIn user if email and password are not provided", () => {
       const errors = { email: "Email is required" };
       mockedFormData.mockReturnValue({ ...errors });
       Validator.formData = mockedFormData.bind(Validator);

--- a/src/__tests__/__views__/ReadArticle.test.js
+++ b/src/__tests__/__views__/ReadArticle.test.js
@@ -145,7 +145,9 @@ describe(" Read article", () => {
   describe("Follow an author", () => {
     test("should map followUser article to props", () => {
       const dispatch = jest.fn();
-      mapDispatchToProps(dispatch).followUser("claude");
+      const location = { pathname: "gdfjbjhgdsfj" };
+      const history = { push: jest.fn() };
+      mapDispatchToProps(dispatch).followUser("claude", { location, history });
       expect(dispatch.mock.calls[0][0]).toBeDefined();
     });
 

--- a/src/__tests__/__views__/ReadArticle.test.js
+++ b/src/__tests__/__views__/ReadArticle.test.js
@@ -145,7 +145,7 @@ describe(" Read article", () => {
   describe("Follow an author", () => {
     test("should map followUser article to props", () => {
       const dispatch = jest.fn();
-      const location = { pathname: "gdfjbjhgdsfj" };
+      const location = { pathname: "/another/fake-url/" };
       const history = { push: jest.fn() };
       mapDispatchToProps(dispatch).followUser("claude", { location, history });
       expect(dispatch.mock.calls[0][0]).toBeDefined();

--- a/src/components/common/Logo/index.js
+++ b/src/components/common/Logo/index.js
@@ -1,13 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
+import logoImage from "../../../assets/img/quill-drawing-a-line.svg";
 
-const Logo = ({ className, ...props }) => (
-  <img
-    src={require("../../../assets/img/quill-drawing-a-line.svg")}
-    alt="logo"
-    className="logo"
-    {...props}
-  />
+const Logo = ({ ...props }) => (
+  <img src={logoImage} alt="logo" className="logo" {...props} />
 );
 
 Logo.propTypes = {

--- a/src/components/common/Logo/index.js
+++ b/src/components/common/Logo/index.js
@@ -1,16 +1,6 @@
 import React from "react";
-import PropTypes from "prop-types";
 import logoImage from "../../../assets/img/quill-drawing-a-line.svg";
 
-const Logo = ({ ...props }) => (
-  <img src={logoImage} alt="logo" className="logo" {...props} />
-);
+const Logo = () => <img src={logoImage} alt="logo" className="logo" />;
 
-Logo.propTypes = {
-  className: PropTypes.string
-};
-
-Logo.defaultProps = {
-  className: "logo"
-};
 export default Logo;

--- a/src/redux/actions/followingActions.js
+++ b/src/redux/actions/followingActions.js
@@ -5,6 +5,7 @@ import {
   FOLLOWING_SUCCESS,
   WAITING_RESPONSE
 } from "../actionTypes";
+import { checkAuth } from "../../utils/checkAuthUtils";
 
 export const followed = () => ({
   type: FOLLOWING_SUCCESS,
@@ -18,7 +19,11 @@ export const unfollowed = () => ({
 
 export const failed = () => ({ type: FOLLOWING_FAILED, payload: false });
 
-export const followUser = username => async dispatch => {
+export const followUser = (
+  username,
+  { location, history }
+) => async dispatch => {
+  checkAuth({ location, history });
   try {
     dispatch({ type: WAITING_RESPONSE });
     const { status } = await axios.post(`/profiles/${username}/follow`);

--- a/src/redux/reducers/authReducers.js
+++ b/src/redux/reducers/authReducers.js
@@ -61,7 +61,7 @@ export default (state = INITIAL_STATE, action) => {
       };
     case SET_CURRENT_USER:
       return {
-        ...INITIAL_STATE,
+        ...state,
         currentUser: payload
       };
     default:

--- a/src/utils/checkAuthUtils.js
+++ b/src/utils/checkAuthUtils.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+/**
+ * function that check if the user is authenticated before doing any action
+ * if not redirect him to log in page
+ * @param  take props object of a component with location and history keys
+ *
+ */
+
+const checkAuth = ({ location: { pathname: currentUrl }, history }) => {
+  const token = localStorage.getItem("token");
+  if (!token) {
+    return history.push(`/sign_in?next=${currentUrl}`);
+  }
+};
+
+const checkAuthComponent = Component => {
+  class AuthenticatedComponent extends React.Component {
+    componentWillMount() {
+      checkAuth(this.props);
+    }
+
+    render() {
+      const token = localStorage.getItem("token");
+      return <div>{token ? <Component {...this.props} /> : ""}</div>;
+    }
+  }
+
+  AuthenticatedComponent.propTypes = {
+    location: PropTypes.shape({
+      pathname: PropTypes.string.isRequired
+    }).isRequired,
+    history: PropTypes.any.isRequired
+  };
+  return connect()(AuthenticatedComponent);
+};
+
+export { checkAuthComponent, checkAuth };

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Link, Redirect } from "react-router-dom";
+import queryString from "query-string";
 import {
   handleTextInput,
   handleSignIn,
@@ -53,10 +54,23 @@ export class Login extends Component {
   }
 
   render() {
-    const { email, password, message, isSubmitting, loginSuccess } = this.props;
+    const {
+      email,
+      password,
+      message,
+      isSubmitting,
+      loginSuccess,
+      history,
+      location
+    } = this.props;
     const { errors } = this.state;
-    if (loginSuccess) {
-      return this.handleNavigation("");
+    if (loginSuccess && location) {
+      const { next: nextUrl } = queryString.parse(location.search);
+      if (!nextUrl) {
+        history.push("/");
+      } else if (localStorage.getItem("token")) {
+        history.push(nextUrl);
+      }
     }
     return (
       <div className="auth" data-test="login">
@@ -155,11 +169,17 @@ Login.propTypes = {
   handleTextInput: PropTypes.func.isRequired,
   message: PropTypes.string,
   loginSuccess: PropTypes.bool.isRequired,
-  socialAuth: PropTypes.func.isRequired
+  socialAuth: PropTypes.func.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired
+  }).isRequired,
+  history: PropTypes.arrayOf(PropTypes.string).isRequired
 };
+
 Login.defaultProps = {
   message: ""
 };
+
 export const mapStateToProps = state => {
   const { auth } = state;
   return {

--- a/src/views/ReadArticle.js
+++ b/src/views/ReadArticle.js
@@ -42,7 +42,8 @@ export const mapStateToProps = ({ auth, fetchedArticle, following }) => ({
 export const mapDispatchToProps = dispatch => ({
   deleteOneArticle: slug => dispatch(deleteArticle(slug)),
   fetchOneArticle: slug => dispatch(fetchArticle(slug)),
-  followUser: username => dispatch(followUser(username)),
+  followUser: (username, { location, history }) =>
+    dispatch(followUser(username, { location, history })),
   reportArticle: (description, slug) =>
     dispatch(reportedArticle(description, slug))
 });
@@ -214,8 +215,8 @@ export class Article extends Component {
   };
 
   followAuthor = username => {
-    const { followUser: followOther } = this.props;
-    followOther(username);
+    const { followUser: followOther, history, location } = this.props;
+    followOther(username, { history, location });
   };
 
   render() {

--- a/src/views/ReadArticle.js
+++ b/src/views/ReadArticle.js
@@ -520,7 +520,8 @@ Article.propTypes = {
     })
   }).isRequired,
   followUser: PropTypes.func.isRequired,
-  following: PropTypes.bool.isRequired
+  following: PropTypes.bool.isRequired,
+  location: PropTypes.shape([]).isRequired
 };
 
 export default withRouter(

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,21 +1,38 @@
 import React, { Component } from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  Redirect
+} from "react-router-dom";
 import MainRoutes from "./routes/MainRoutes";
 import AuthRoutes from "./routes/AuthRoutes";
 
 export default class Routers extends Component {
   render() {
+    const token = localStorage.getItem("token");
     return (
       <Router>
         <Switch>
-          {AuthRoutes.map((route, key) => (
-            <Route
-              exact
-              path={route.path}
-              component={route.component}
-              key={Number(key)}
-            />
-          ))}
+          {AuthRoutes.map((route, key) =>
+            route.path !== "/update_password" ? (
+              <Route
+                exact
+                path={route.path}
+                key={Number(key)}
+                render={props =>
+                  token ? <Redirect to="/" /> : <route.component {...props} />
+                }
+              />
+            ) : (
+              <Route
+                exact
+                path={route.path}
+                component={route.component}
+                key={Number(key)}
+              />
+            )
+          )}
           <MainRoutes />
         </Switch>
       </Router>

--- a/src/views/routes/MainRoutes.js
+++ b/src/views/routes/MainRoutes.js
@@ -9,6 +9,7 @@ import EditProfile from "../EditProfile";
 import Profile from "../Profile";
 import Settings from "../Settings";
 import Search from "../SearchResults";
+import { checkAuthComponent } from "../../utils/checkAuthUtils";
 
 export const routes = [
   {
@@ -21,7 +22,8 @@ export const routes = [
   },
   {
     path: "/articles/new",
-    component: CreateEditArticle
+    component: CreateEditArticle,
+    requireAuth: true
   },
   {
     path: "/articles/:slug",
@@ -30,7 +32,8 @@ export const routes = [
 
   {
     path: "/articles/:slug/edit",
-    component: CreateEditArticle
+    component: CreateEditArticle,
+    requireAuth: true
   },
   {
     path: "/profiles/:username",
@@ -56,14 +59,23 @@ export default class MainRoutes extends Component {
       <div>
         <Navbar />
         <Switch>
-          {routes.map((route, index) => (
-            <Route
-              exact
-              path={route.path}
-              component={route.component}
-              key={Number(index)}
-            />
-          ))}
+          {routes.map((route, index) =>
+            route.requireAuth ? (
+              <Route
+                exact
+                path={route.path}
+                component={checkAuthComponent(route.component)}
+                key={Number(index)}
+              />
+            ) : (
+              <Route
+                exact
+                path={route.path}
+                component={route.component}
+                key={Number(index)}
+              />
+            )
+          )}
           <Route component={NotFound} />
         </Switch>
       </div>


### PR DESCRIPTION
#### What does this PR do?
Create a high order component that protects routes that require authentication.
#### Description of Task to be completed?
- Create a HOC that redirects  unauthenticated  to sign in when they want to perform an action that requires authentication
- Redirect authenticated users to the home page when they want to sign in twice
- Unittest the high order component
#### How should this be manually tested?
- clone the repo and check out the following branch `ch-create-high-order-component-165763482`
- run `yarn start`
- make sure you are not logged in.
- try to access the following endpoint: `http://localhost:8000/articles/new`
- check if you are redirected here: `http://localhost:8000/sign_in?next=/articles/new`
- log in and check if you are redirected back to `http://localhost:8000/articles/new`
- run  `yarn test` to  run the unit tests
#### Any background context you want to provide?
Many endpoints needed this HOC to be protected.
#### What are the relevant pivotal tracker stories?
#165763482
#### Screenshots (if appropriate)
#### Questions:
None
#### How to use this component to protect my route : 
While adding your route in the file `src/views/routes/MainRoutes.js`, if it requires authentication set the requireAuth key to true : 
Example 
```
{path: "/articles/:slug/edit",
component: EditArticle,
requireAuth: true}
```